### PR TITLE
bug: fix identity server profile page showing client secret label as client id

### DIFF
--- a/backend/src/Squidex/Areas/IdentityServer/Views/Profile/Profile.cshtml
+++ b/backend/src/Squidex/Areas/IdentityServer/Views/Profile/Profile.cshtml
@@ -198,14 +198,14 @@
 
     <div class="row no-gutters form-group">
         <div class="col-8">
-            <label for="clientId">Client Id</label>
+            <label for="clientId">@T.Get("common.clientId")</label>
 
             <input class="form-control" name="clientId" id="clientId" readonly value="@Model.Id" />
         </div>
     </div>
     <div class="row no-gutters form-group">
         <div class="col-8">
-            <label for="clientSecret">@T.Get("common.clientId")</label>
+            <label for="clientSecret">@T.Get("common.clientSecret")</label>
 
             <input class="form-control" name="clientSecret" id="clientSecret" readonly value="@Model.ClientSecret" />
         </div>


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/6273429/101248893-0012b900-3715-11eb-8930-b27ec40d5021.png)
